### PR TITLE
Fix: bugs in recourse methods to run experiments

### DIFF
--- a/recourse_methods/catalog/gravitational/model.py
+++ b/recourse_methods/catalog/gravitational/model.py
@@ -101,6 +101,7 @@ class Gravitational(RecourseMethod):
             hyperparams, self._DEFAULT_HYPERPARAMS
         )
 
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.mlmodel = mlmodel
         self.prediction_loss_lambda = checked_hyperparams["prediction_loss_lambda"]
         self.original_dist_lambda = checked_hyperparams["original_dist_lambda"]
@@ -122,9 +123,12 @@ class Gravitational(RecourseMethod):
         self.criterion = nn.CrossEntropyLoss()
 
     def prediction_loss(self, model, x_cf, target_class):
+        x_cf = x_cf.to(self.device)
         output = model.predict_proba(x_cf)
+        target_class = torch.tensor([target_class] * output.size(0), dtype=torch.long).to(self.device)
+        
         loss = self.criterion(
-            output, torch.tensor([target_class] * output.size(0), dtype=torch.long)
+            output, target_class
         )
         return loss
 

--- a/recourse_methods/catalog/mace/library/mace.py
+++ b/recourse_methods/catalog/mace/library/mace.py
@@ -41,6 +41,11 @@ from sklearn.tree import DecisionTreeClassifier
 from . import normalizedDistance
 from .modelConversion import forest2formula, lr2formula, mlp2formula, tree2formula
 
+from pysmt.environment import reset_env, get_env
+
+reset_env()
+get_env().enable_infix_notation = True
+
 RANDOM_SEED = 1122334455
 seed(
     RANDOM_SEED

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -363,7 +363,8 @@ if __name__ == "__main__":
                 # face_knn requires datasets with immutable features.
                 if exists_already or (
                     "face" in method_name
-                    and (data_name == "mortgage" or data_name == "twomoon")
+                    and (data_name == "mortgage" or data_name == "twomoon" 
+                         or data_name == "boston_housing" or data_name == "breast_cancer")
                 ):
                     continue
 


### PR DESCRIPTION
To generate result.csv, I fixed some bugs in run_experiment.py.
The device bug was resolved for claproar and gravitational, which use the PyTorch backend.
Face_knn accepts datasets with immutable features, so two added datasets were excluded from those experiments.
Several experiments on mace caused mismatches in the pysmt environment variables. To fix this, the environment was reset for each experiment.

_There is still a bug in the greedy method, which results in an infinite loop._