### PR TITLE
Fix: cuda device bug in claproar and gravitational

### DIFF
--- a/models/catalog/catalog.py
+++ b/models/catalog/catalog.py
@@ -96,6 +96,9 @@ class ModelCatalog(MLModel):
             data.name,
             self._backend,
         )
+        if(self.backend == "pytorch"):    
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            self._model = self._model.to(device)
 
     def _test_accuracy(self):
         # get preprocessed data

--- a/recourse_methods/catalog/claproar/model.py
+++ b/recourse_methods/catalog/claproar/model.py
@@ -84,6 +84,7 @@ class ClaPROAR(RecourseMethod):
             hyperparams, self._DEFAULT_HYPERPARAMS
         )
 
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.mlmodel = mlmodel
         self.individual_cost_lambda = checked_hyperparams["individual_cost_lambda"]
         self.external_cost_lambda = checked_hyperparams["external_cost_lambda"]
@@ -95,16 +96,20 @@ class ClaPROAR(RecourseMethod):
         self.criterion = nn.CrossEntropyLoss()
 
     def compute_yloss(self, x_prime):
+        x_prime = x_prime.to(self.device)
         output = self.mlmodel.predict_proba(x_prime)
-        yloss = self.criterion(output, torch.tensor([self.target_class] * output.size(0), dtype=torch.long))
+        target_class = torch.tensor([self.target_class] * output.size(0), dtype=torch.long).to(self.device)
+        yloss = self.criterion(output, target_class)
         return yloss
 
     def compute_individual_cost(self, x, x_prime):
         return torch.norm(x - x_prime)
 
     def compute_external_cost(self, x_prime):
+        x_prime = x_prime.to(self.device)
         output = self.mlmodel.predict_proba(x_prime)
-        ext_cost = self.criterion(output, torch.tensor([1 - self.target_class] * output.size(0), dtype=torch.long))
+        target_class = torch.tensor([1- self.target_class] * output.size(0), dtype=torch.long).to(self.device)
+        ext_cost = self.criterion(output, target_class)
         return ext_cost
 
     def compute_costs(self, x, x_prime):

--- a/recourse_methods/catalog/gravitational/model.py
+++ b/recourse_methods/catalog/gravitational/model.py
@@ -101,6 +101,7 @@ class Gravitational(RecourseMethod):
             hyperparams, self._DEFAULT_HYPERPARAMS
         )
 
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.mlmodel = mlmodel
         self.prediction_loss_lambda = checked_hyperparams["prediction_loss_lambda"]
         self.original_dist_lambda = checked_hyperparams["original_dist_lambda"]
@@ -122,9 +123,11 @@ class Gravitational(RecourseMethod):
         self.criterion = nn.CrossEntropyLoss()
 
     def prediction_loss(self, model, x_cf, target_class):
+        x_cf = x_cf.to(self.device)
         output = model.predict_proba(x_cf)
+        target_class = torch.tensor([target_class] * output.size(0), dtype=torch.long).to(self.device)
         loss = self.criterion(
-            output, torch.tensor([target_class] * output.size(0), dtype=torch.long)
+            output, target_class
         )
         return loss
 


### PR DESCRIPTION
There was a bug in claproar and gravitational methods related to device compatibility. Now it's been fixed by falling back to the CPU if a CUDA device is unavailable. 